### PR TITLE
validate invalid characters: [a-zA-Z@\*\#] are acceptable only

### DIFF
--- a/src/CUSIP.php
+++ b/src/CUSIP.php
@@ -82,12 +82,10 @@ class CUSIP {
 
         $checksumDigit = CUSIP::getChecksumDigit( $cusip );
         // If the last character of the cusip is equal to the checksum digit, then it validates.
-        if ( substr( $cusip,
-                     -1 ) == $checksumDigit
-        ):
+        $isValid = $checksumDigit !== false && (\substr($cusip, -1) == $checksumDigit);
+        if ($isValid) {
             return true;
-        endif;
-
+        }
         return false;
     }
 
@@ -135,6 +133,10 @@ class CUSIP {
                 $position = $ord - 96;
                 $v        = $position + 9; // S&P encodes A == 10, and so on.
             endif;
+            if ($v === null) {
+                // invalid character is provided
+                return false;
+            }
             // Of the 8 characters we are checking, if the character being checked right now is
             // in an odd position, then we are supposed to double it's value. Example: 6 becomes 12
             if ( ( $i % 2 ) != 0 ):

--- a/tests/CUSIPTest.php
+++ b/tests/CUSIPTest.php
@@ -139,6 +139,16 @@ class CUSIPTest extends TestCase {
         $this->assertFalse( $isCusip );
     }
 
+
+    public function testIsCusipWithInvalidCheckInvalidCharacters() {
+        $isCusip = CUSIP::isCUSIP('1234' . \chr(0) . '6787');
+        static::assertFalse($isCusip);
+
+        $isCusip = CUSIP::isCUSIP('1234' . \chr(127) . '6787');
+        static::assertFalse($isCusip);
+    }
+
+
     /**
      * @test
      */


### PR DESCRIPTION
CUSIP like '1234' . \chr(127) . '6787' should not be valid.